### PR TITLE
Add blog and research pages

### DIFF
--- a/components/AboutSection.js
+++ b/components/AboutSection.js
@@ -2,7 +2,7 @@ export default function AboutSection() {
     return (
       <section id="about" className="bg-white py-16 px-6">
         <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-3xl font-bold mb-4">About A Simple Company</h2>
+          <h2 className="text-3xl font-bold font-serif mb-4">About A Simple Company</h2>
           <p className="text-gray-700 leading-relaxed">
             A Simple Company helps people and businesses explore new possibilities at the intersection of human intelligence and artificial intelligence.
             Our AI Research Museum is a living exploration—documenting insights, interpretability, and collaborative discovery. 

--- a/components/HeroSection.js
+++ b/components/HeroSection.js
@@ -2,7 +2,7 @@ export default function HeroSection() {
     return (
       <section className="text-center py-28 px-4 bg-parchment text-graphite">
         <div className="max-w-4xl mx-auto">
-          <h2 className="text-5xl sm:text-6xl font-bold leading-tight mb-6 tracking-tight">
+        <h2 className="text-5xl sm:text-6xl font-bold font-serif leading-tight mb-6 tracking-tight">
             Welcome to the AI Research Museum
           </h2>
           <p className="text-xl text-gray-700 mb-10 max-w-2xl mx-auto">

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -10,7 +10,7 @@ export default function Navbar() {
     <nav className="backdrop-blur-md bg-white/80 border-b border-gray-200 shadow-sm">
       <div className="max-w-6xl mx-auto flex justify-between items-center px-6 py-4">
         <Link href="/">
-          <span className="text-xl font-semibold tracking-wide uppercase text-gray-800 cursor-pointer">
+          <span className="text-xl font-semibold font-serif tracking-wide uppercase text-gray-800 cursor-pointer">
             A Simple Company
           </span>
         </Link>
@@ -59,7 +59,6 @@ export default function Navbar() {
               <div className="absolute top-full left-0 mt-2 bg-white rounded shadow p-4 w-56 text-sm z-50">
                 <Link href="#submit"><div className="hover:text-gold pb-2 cursor-pointer">Contribute a Prompt</div></Link>
                 <Link href="/experiments"><div className="hover:text-gold pb-2 cursor-pointer">Join an Experiment</div></Link>
-                <Link href="/suggest"><div className="hover:text-gold pb-2 cursor-pointer">Suggest a Topic</div></Link>
                 <Link href="/donate"><div className="hover:text-gold cursor-pointer">Donate</div></Link>
               </div>
             )}

--- a/components/PromptForm.js
+++ b/components/PromptForm.js
@@ -17,7 +17,7 @@ export default function PromptForm() {
   return (
     <section id="submit" className="bg-white text-graphite py-24 px-6 border-t border-gray-200">
       <div className="max-w-3xl mx-auto text-center">
-        <h2 className="text-4xl font-bold mb-4">Submit a Journey Prompt</h2>
+        <h2 className="text-4xl font-bold font-serif mb-4">Submit a Journey Prompt</h2>
         <p className="text-lg text-gray-600 mb-8">
           Share an idea or prompt you'd like to see explored. We'll credit you if it's featured in our public research logs.
         </p>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,7 +7,7 @@ export default function MyApp({ Component, pageProps }) {
       <Head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet" />
       </Head>
       <Component {...pageProps} />
     </>

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,0 +1,33 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+import Link from 'next/link';
+
+const posts = [
+  { slug: 'welcome', title: 'Welcome to the AI Research Museum', excerpt: 'An introduction to our mission and what you can find here.' },
+  { slug: 'interpreting-models', title: 'Interpreting Large Language Models', excerpt: 'A quick overview of interpretability techniques we are exploring.' },
+];
+
+export default function BlogIndex() {
+  return (
+    <Layout>
+      <Head>
+        <title>Blog | AI Research Museum</title>
+      </Head>
+      <section className="bg-parchment py-20 px-6">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-8">Blog</h1>
+          <div className="space-y-8">
+            {posts.map((post) => (
+              <article key={post.slug} className="bg-white p-6 rounded shadow">
+                <h2 className="text-2xl font-serif font-semibold mb-2">
+                  <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                </h2>
+                <p className="text-gray-700">{post.excerpt}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/pages/blog/interpreting-models.js
+++ b/pages/blog/interpreting-models.js
@@ -1,0 +1,18 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+
+export default function InterpretingModelsPost() {
+  return (
+    <Layout>
+      <Head>
+        <title>Interpreting Models | AI Research Museum</title>
+      </Head>
+      <article className="bg-parchment py-20 px-6 min-h-screen">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-4">Interpreting Large Language Models</h1>
+          <p className="text-gray-700 mb-4">We share initial thoughts on how to peer inside transformer networks.</p>
+        </div>
+      </article>
+    </Layout>
+  );
+}

--- a/pages/blog/welcome.js
+++ b/pages/blog/welcome.js
@@ -1,0 +1,18 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+
+export default function WelcomePost() {
+  return (
+    <Layout>
+      <Head>
+        <title>Welcome | AI Research Museum</title>
+      </Head>
+      <article className="bg-parchment py-20 px-6 min-h-screen">
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-4">Welcome to the AI Research Museum</h1>
+          <p className="text-gray-700 mb-4">This is a short introduction to our blog. More content coming soon.</p>
+        </div>
+      </article>
+    </Layout>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ export default function Home() {
       <PromptForm />
 
       <section id="chat" className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-8">
-        <h1 className="text-3xl font-bold mb-6">AI Research Museum Chat</h1>
+        <h1 className="text-3xl font-bold font-serif mb-6">AI Research Museum Chat</h1>
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/pages/research/experiments.js
+++ b/pages/research/experiments.js
@@ -1,0 +1,18 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+
+export default function Experiments() {
+  return (
+    <Layout>
+      <Head>
+        <title>Experiments | AI Research Museum</title>
+      </Head>
+      <section className="bg-parchment py-20 px-6 min-h-screen">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-4">Experiments</h1>
+          <p className="text-gray-700">Participatory experiments will be listed here soon.</p>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/pages/research/index.js
+++ b/pages/research/index.js
@@ -1,0 +1,34 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+import Link from 'next/link';
+
+const areas = [
+  { slug: 'interpretability', title: 'Interpretability', description: 'Understanding how models reason internally.' },
+  { slug: 'introspection', title: 'Introspection', description: 'Using models to analyze their own behavior.' },
+  { slug: 'experiments', title: 'Experiments', description: 'Collaborative trials and research notes.' },
+];
+
+export default function ResearchIndex() {
+  return (
+    <Layout>
+      <Head>
+        <title>Research | AI Research Museum</title>
+      </Head>
+      <section className="bg-parchment py-20 px-6">
+        <div className="max-w-5xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-10">Research Areas</h1>
+          <div className="grid gap-8 md:grid-cols-3">
+            {areas.map((area) => (
+              <Link key={area.slug} href={`/research/${area.slug}`}>
+                <div className="bg-white p-6 rounded shadow cursor-pointer hover:shadow-lg transition">
+                  <h2 className="text-2xl font-serif font-semibold mb-2">{area.title}</h2>
+                  <p className="text-gray-700">{area.description}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/pages/research/interpretability.js
+++ b/pages/research/interpretability.js
@@ -1,0 +1,18 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+
+export default function Interpretability() {
+  return (
+    <Layout>
+      <Head>
+        <title>Interpretability | AI Research Museum</title>
+      </Head>
+      <section className="bg-parchment py-20 px-6 min-h-screen">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-4">Interpretability</h1>
+          <p className="text-gray-700">Detailed notes and resources coming soon.</p>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/pages/research/introspection.js
+++ b/pages/research/introspection.js
@@ -1,0 +1,18 @@
+import Layout from '../../components/Layout';
+import Head from 'next/head';
+
+export default function Introspection() {
+  return (
+    <Layout>
+      <Head>
+        <title>Introspection | AI Research Museum</title>
+      </Head>
+      <section className="bg-parchment py-20 px-6 min-h-screen">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-4xl font-serif font-bold mb-4">Introspection</h1>
+          <p className="text-gray-700">Research updates will appear here soon.</p>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  @apply font-sans text-graphite;
+}
+
 @layer utilities {
   .bg-gradient-radial {
     background: radial-gradient(ellipse at center, #fff8dc 0%, #e8d5b0 40%, #1b1f30 100%);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,8 @@ module.exports = {
         graphite: '#3a3a3a',
       },
       fontFamily: {
-        sans: ['"Inter"', 'sans-serif']
+        sans: ['"Inter"', 'sans-serif'],
+        serif: ['"Playfair Display"', 'serif']
       }
     }
   },


### PR DESCRIPTION
## Summary
- add blog index with placeholder posts
- add research pages with grid of research areas
- implement Playfair Display font for headings
- add serif headings across components
- use serif site branding and fix navbar dropdowns
- set base fonts in global stylesheet

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fe2cc7d0483278f2b75118aa04214